### PR TITLE
preWrite and postWrite handlers in dest

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,8 +108,13 @@ function plugin(app) {
     if (!dir) {
       throw new TypeError('expected dest to be a string or function.');
     }
-    return handle(this, 'preWrite')
-      .pipe(vfs.dest.apply(vfs, arguments))
+    var output = utils.combine([
+      handle(this, 'preWrite'),
+      vfs.dest.apply(vfs, arguments),
+      handle(this, 'postWrite')
+    ]);
+    output.on('end', output.emit.bind(output, 'finish'));
+    return output;
   });
 }
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "extend-shallow": "^2.0.1",
     "lazy-cache": "^1.0.3",
+    "stream-combiner": "^0.2.2",
     "through2": "^2.0.0",
     "vinyl-fs": "^2.2.1"
   },

--- a/test/app.dest.js
+++ b/test/app.dest.js
@@ -954,6 +954,26 @@ describe('dest stream', function () {
     stream.write(file);
     stream.end();
   });
+
+  it('should emit end event', function (done) {
+    var srcPath = path.join(__dirname, './fixtures/vinyl/test.coffee');
+    var stream = app.dest('./out-fixtures/', {
+      cwd: __dirname
+    });
+
+    stream.once('end', function () {
+      done();
+    });
+
+    var file = new File({
+      path: srcPath,
+      cwd: __dirname,
+      contents: new Buffer("1234567890")
+    });
+
+    stream.write(file);
+    stream.end();
+  });
 });
 
 describe('dest', function () {

--- a/test/handlers.js
+++ b/test/handlers.js
@@ -1,0 +1,77 @@
+'use strict';
+
+var path = require('path');
+var assert = require('assert');
+var should = require('should');
+var rimraf = require('rimraf');
+var File = require('vinyl');
+var App = require('templates');
+var fs = require('..');
+var app
+
+describe('handlers', function() {
+  beforeEach(function() {
+    app = new App();
+    app.use(fs());
+  });
+
+  afterEach(function(cb) {
+    rimraf(path.join(__dirname, './out-fixtures/'), cb);
+  });
+
+  it('should emit on preWrite', function(cb) {
+    var count = 0;
+    app.preWrite(/./, function(file, next) {
+      count++;
+      next();
+    });
+
+    var srcPath = path.join(__dirname, './fixtures/vinyl/test.coffee');
+    var stream = app.dest('./out-fixtures/', {
+      cwd: __dirname
+    });
+
+    stream.once('finish', function () {
+      assert.equal(count, 1);
+      cb();
+    });
+
+    var file = new File({
+      path: srcPath,
+      cwd: __dirname,
+      contents: new Buffer("1234567890")
+    });
+    file.options = {};
+
+    stream.write(file);
+    stream.end();
+  });
+
+  it('should emit on postWrite', function(cb) {
+    var count = 0;
+    app.postWrite(/./, function(file, next) {
+      count++;
+      next();
+    });
+
+    var srcPath = path.join(__dirname, './fixtures/vinyl/test.coffee');
+    var stream = app.dest('./out-fixtures/', {
+      cwd: __dirname
+    });
+
+    stream.once('finish', function () {
+      assert.equal(count, 1);
+      cb();
+    });
+
+    var file = new File({
+      path: srcPath,
+      cwd: __dirname,
+      contents: new Buffer("1234567890")
+    });
+    file.options = {};
+
+    stream.write(file);
+    stream.end();
+  });
+});

--- a/utils.js
+++ b/utils.js
@@ -10,6 +10,7 @@ var fn = require;
 require = utils;
 require('extend-shallow', 'extend');
 require('through2', 'through');
+require('stream-combiner', 'combine');
 require('vinyl-fs', 'vfs');
 require = fn;
 


### PR DESCRIPTION
Getting the `preWrite` and `postWrite` handlers working in `.dest`.
Added tests for the handlers.
