### PR TITLE
options.onLoad

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,6 +81,7 @@ function plugin(app) {
 
   app.mixin('src', function(glob, options) {
     var opts = utils.extend({ allowEmpty: true, onLoad: false }, options);
+    this.options.onLoad = false;
     return utils.vfs.src(glob, opts)
       .pipe(toCollection(this, opts))
       .pipe(utils.handle(this, 'onLoad'))

--- a/index.js
+++ b/index.js
@@ -80,8 +80,7 @@ function plugin(app) {
    */
 
   app.mixin('src', function(glob, options) {
-    var opts = utils.extend({ allowEmpty: true, onLoad: false }, options);
-    this.options.onLoad = false;
+    var opts = utils.extend({ allowEmpty: true }, options);
     return utils.vfs.src(glob, opts)
       .pipe(toCollection(this, opts))
       .pipe(utils.handle(this, 'onLoad'))
@@ -148,6 +147,9 @@ function toCollection(app, options) {
     if (file.isNull()) {
       return next();
     }
+
+    // disable default `onLoad` handling inside templates
+    file.options = utils.extend({ onLoad: false }, file.options);
 
     if (app.isApp) {
       view = collection.setView(file.path, file);

--- a/index.js
+++ b/index.js
@@ -16,12 +16,10 @@ var utils = require('./utils');
 module.exports = function() {
   return function() {
     if (!this.isApp) return;
-    this.options.onLoad = false;
     plugin.call(this, this);
 
     return function() {
       if (!this.isCollection) return;
-      this.options.onLoad = false;
       plugin.call(this, this);
     };
   };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "assemble-fs",
   "description": "Assemble plugin to add methods to assemble for working with the file system, like src, dest, copy and symlink.",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "homepage": "https://github.com/assemble/assemble-fs",
   "author": "Jon Schlinkert (https://github.com/jonschlinkert)",
   "repository": "assemble/assemble-fs",


### PR DESCRIPTION
Remove setting `this.options.onLoad = false` when plugin is created to keep default functionality when `.src` is not used.

@jonschlinkert I'm not able to push to this repo for some reason.
